### PR TITLE
Adjust grid layouts

### DIFF
--- a/app/projects/components/ProjectCard.tsx
+++ b/app/projects/components/ProjectCard.tsx
@@ -44,13 +44,13 @@ export default function ProjectCard({
       whileInView='projectCard'
       viewport={{ once: true }}
       custom={delay}
-      className='project-hover sm:max-w-[400px]'
+      className='project-hover max-w-[450px] md:max-w-[550px] justify-self-center'
     >
       <Card className='h-full sm:grid grid-rows-[1fr_0.25fr_50px]'>
-        <CardHeader className='grid grid-rows-[30px_80px_230px]'>
+        <CardHeader className='grid grid-rows-[30px_100px_230px] md:grid-rows-[30px_70px_280px]'>
           <CardTitle>{title}</CardTitle>
           <SkillBadge skills={skills} />
-          <div className='w-full h-[200px] relative border-4 border-double rounded-lg'>
+          <div className='w-full h-[200px] md:h-[250px] relative border-4 border-double rounded-lg'>
             <Image
               className='flex-grow object-cover bg-no-repeat rounded-lg'
               src={src}

--- a/app/projects/components/ProjectContainer.tsx
+++ b/app/projects/components/ProjectContainer.tsx
@@ -10,7 +10,7 @@ export default function ProjectContainer() {
     <motion.div
       variants={pageVariant}
       animate='projectList'
-      className='flex flex-col gap-4 justify-center sm:grid sm:grid-cols-2 md:grid-cols-3 '
+      className='flex flex-col gap-4 justify-center sm:grid md:grid-cols-2 xl:grid-cols-3 '
     >
       {allProjects.map((project, idx) => (
         <ProjectCard


### PR DESCRIPTION
Adjust grid layouts based on various viewport sizes.

- Single column up to "sm" viewports
- On "md" viewport, grid column increased to 2
- On "xl" viewport, grid column increased to 3

Accommodations for ProjectCards are also made in response to the different grid change 
- Centered grid items
- Increased max width for cards to fill space
- Increased image sizes based on viewport